### PR TITLE
Disable Browser Check to support Perfecto Mobile Custom Browser

### DIFF
--- a/setup/index.js
+++ b/setup/index.js
@@ -64,6 +64,10 @@ function Setup() {
       }
 
       function getCapabilities() {
+        if (nemoData.useCustomBrowser) {
+          // for custom browser, first set default selenium caps for firefox, then overwrite with custom caps
+          tgtBrowser = 'firefox';
+        }
         //specified valid webdriver browser key?
         if (!webdriver.Capabilities[tgtBrowser]) {
           error('You have specified ' + tgtBrowser + ' which is an invalid webdriver.Capabilities browser option');


### PR DESCRIPTION
Added option to disable custom browser check.

This is needed because perfecto mobile has their own jar file which only works by setting the browser to "pm".