### PR TITLE
Driver override

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ var setup = function setup(config, cb) {
     'data': config.get('data'),
     'driver': {},
     'wd': webdriver,
-    '_config': null
+    '_config': config 
   };
   //config is for registering plugins
   if (config && config.get('plugins')) {

--- a/index.js
+++ b/index.js
@@ -98,6 +98,10 @@ function Nemo(_basedir, _configOverride, _cb) {
   _.merge(configOverride, envdata.json, envdriver.json, envplugins.json);
 
   confit(confitOptions).addOverride(configOverride).create(function (err, config) {
+    if (err) {
+      error('Error encountered during confit.create');
+      return cb(err);
+    }
     //reset env variables
     envdata.reset();
     envdriver.reset();
@@ -132,7 +136,6 @@ var setup = function setup(config, cb) {
     postDriverArray = [],
     plugins = {},
     pluginError = false;
-  var driverConfig = config.get('driver');
   var nemo = {
     'data': config.get('data'),
     'driver': {},
@@ -175,7 +178,7 @@ var setup = function setup(config, cb) {
   if (pluginError) {
     return;
   }
-  waterFallArray = preDriverArray.concat([driversetup(nemo, driverConfig)], postDriverArray);
+  waterFallArray = preDriverArray.concat([driversetup(nemo)], postDriverArray);
 
   async.waterfall(waterFallArray, function waterfall(err, result) {
     if (err) {
@@ -187,8 +190,9 @@ var setup = function setup(config, cb) {
 
 };
 
-var driversetup = function (_nemo, driverConfig) {
+var driversetup = function (_nemo) {
   return function driversetup(callback) {
+    var driverConfig = _nemo._config.get('driver');
     //do driver/view/locator/vars setup
     (Setup()).doSetup(driverConfig, function setupCallback(err, _driver) {
       if (err) {


### PR DESCRIPTION
This fixes the driver config being fixed before plugin registration. With this fix, if a pre-driver plugin modifies the driver property, that modification will be used to start the driver.