### PR TITLE
add logic to prefer builders.forBrowser and builders.usingServer over…

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,19 +344,16 @@ Here are the `driver` properties recognized by Nemo. This is ALL of them. Please
 
 #### browser (optional)
 
-Browser you wish to automate. Make sure that your chosen webdriver has this browser option available. While this is "optional" you must choose a browser. Either use this property or the "builders.forBrowser" option (see below).
+Browser you wish to automate. Make sure that your chosen webdriver has this browser option available. While this is "optional" you must choose a browser. Either use this property or the `builders.forBrowser` option (see below). 
+If both are specified, `builders.forBrowser` takes precedence.
 
 #### local (optional, defaults to false)
 
 Set local to true if you want Nemo to attempt to start a standalone binary on your system (like selenium-standalone-server) or use a local browser/driver like Chrome/chromedriver or PhantomJS.
 
-#### selenium.version (optional)
-
-If you want to override selenium-webdriver version used by nemo, you can provide `selenium.version` of your choice
-
 #### server (optional)
 
-Webdriver server URL you wish to use.
+Webdriver server URL you wish to use. This setting will be overridden if you are using `builders.usingServer`
 
 #### serverProps (optional/conditional)
 

--- a/setup/index.js
+++ b/setup/index.js
@@ -106,10 +106,10 @@ function Setup() {
             builder = builder[bldr].apply(builder, builders[bldr]);
           });
         }
-        if (serverUrl !== undefined) {
+        if (serverUrl !== undefined && !(builders && builders.usingServer)) {
           builder = builder.usingServer(getServer());
         }
-        if (tgtBrowser !== undefined) {
+        if (tgtBrowser !== undefined && !(builders && builders.forBrowser)) {
           builder = builder.withCapabilities(getCapabilities());
         }
         if (proxyDetails !== undefined) {

--- a/test/override.js
+++ b/test/override.js
@@ -33,6 +33,24 @@ describe('@override@', function () {
       done();
     });
   });
+  it("@builders@ overrides tgtBrowser abstraction", function (done) {
+    process.env.nemoBaseDir = path.join(process.cwd(), 'test');
+
+    nemo = Nemo({
+      driver: {
+        browser: 'firefox'
+      },
+      data: {
+        baseUrl: 'http://www.ebay.com'
+      }
+    }, function () {
+      nemo.driver.getCapabilities().then(function (caps) {
+        assert.notEqual(caps.browserName, 'firefox');
+        nemo.driver.quit();
+        done();
+      });
+    });
+  });
 });
 
 


### PR DESCRIPTION
… the browser/server shorthand configs.

In a nutshell, if the user provides configuration for a grid server via `builders.usingServer` or a browser via `builders.forBrowser`, these will take precedent over the nemo configuration shorthand of `server` and `browser`. This allows for a simple `config.json` which uses the shorthands, but for overriding configs to use the `builders` object for more advanced configuration (i.e. appium, etc)

Please see:
https://github.com/paypal/nemo/issues/103

Also removed wayward documentation about the currently experimental feature `webdriver.version`