### PR TITLE
resolved issue #120 - nemo-example-app link

### DIFF
--- a/pages/getting-started.html
+++ b/pages/getting-started.html
@@ -132,7 +132,7 @@ describe('suite using @generic@ nemo-view methods', function () {
                 <li><a href="https://github.com/paypal/nemo-view">use the "locator" feature of nemo-view</a></li>
                 <li>integrate your test suite using a task runner like <a href="https://www.npmjs.com/package/grunt">grunt</a> or <a href="https://www.npmjs.com/package/gulp">gulp</a></li>
                 <li>differentiate test environments using the configuration features of nemo</li>
-                <li>The <a href="">nemo-example-app</a> illustrates all of the above. It can be a good place to find ideas and patterns.</li>
+                <li>The <a href="https://github.com/paypal/nemo-example-app">nemo-example-app</a> illustrates all of the above. It can be a good place to find ideas and patterns.</li>
             </ul>
         </p>
             </div>


### PR DESCRIPTION
updated the nemo-example-app link at the bottom of getting-started.html to link to the example app's github page