### PR TITLE
bumps outdated versions, selenium-webdriver had a nsa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,28 @@
 # nemo CHANGELOG
 
+##
+
+Selenium web driver was outdated and had a node security advisory. Bumped other outdated modules;
+
+- async@~0.2.8 -> async@^1.5.2
+- lodash@^2.4.0 -> lodash@^4.12.0
+- selenium-webdriver@~2.48.0 -> selenium-webdriver@^2.53.2
+- yargs@^3.6.0 -> yargs@^4.7.1
+- chai@~1.6.0 -> chai@^3.5.0
+- grunt@~0.4.1 -> grunt@^1.0.1
+- grunt-contrib-jshint@~0.7.1 -> grunt-contrib-jshint@^1.0.0
+
 ## v2.2.0
 
 * add `selenium.version` feature. Please see: https://github.com/paypal/nemo/pull/107
 
-## v2.1.1 
+## v2.1.1
 
 * add resolved nemo as the second argument to the constructor's callback. See: https://github.com/paypal/nemo/pull/114
 
 ## v2.1.0 [UNPUBLISHED]
 
-* add ability to install custom selenium-webdriver version. Please see #98 
+* add ability to install custom selenium-webdriver version. Please see #98
 * unfortunately the addition of this feature caused some unintended consequences via the `npmi` module. Please see #102
 
 ## v2.0.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Join the chat at https://gitter.im/paypal/nemo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/paypal/nemo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![JS.ORG](https://img.shields.io/badge/js.org-nemo-ffb400.svg?style=flat-square)](http://js.org)
+[![Dependency Status](https://david-dm.org/paypal/nemo.svg)](https://david-dm.org/paypal/nemo)
+[![devDependency Status](https://david-dm.org/paypal/nemo/dev-status.svg)](https://david-dm.org/paypal/nemo#info=devDependencies)
 
 Nemo provides a simple way to add selenium automation to your NodeJS web projects. With a powerful configuration ability provided by [krakenjs/confit](https://github.com/krakenjs/confit), and plugin
 architecture, Nemo is flexible enough to handle any browser/device automation need.
@@ -414,7 +416,7 @@ The nemo setup routine will prefer these "builder" properties over other abstrac
 
 #### selenium.version (optional)
 
-Since nemo requires a narrow range of versions of selenium-webdriver, you may have a need to upgrade selenium-webdriver (or downgrade) outside of the supported versions that nemo uses. 
+Since nemo requires a narrow range of versions of selenium-webdriver, you may have a need to upgrade selenium-webdriver (or downgrade) outside of the supported versions that nemo uses.
 You can do that by using `selenium.version`. E.g.
 
 ```js

--- a/package.json
+++ b/package.json
@@ -6,19 +6,19 @@
     "test": "grunt"
   },
   "dependencies": {
-    "async": "~0.2.8",
+    "async": "^1.5.2",
     "confit": "^2.0.0",
     "debug": "^2.1.0",
-    "lodash": "^2.4.0",
-    "selenium-webdriver": "~2.48.0",
+    "lodash": "^4.12.0",
+    "selenium-webdriver": "^2.53.2",
     "shortstop-handlers": "^1.0.0",
-    "yargs": "^3.6.0"
+    "yargs": "^4.7.1"
   },
   "main": "index.js",
   "devDependencies": {
-    "chai": "~1.6.0",
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.7.1",
+    "chai": "^3.5.0",
+    "grunt": "^1.0.1",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-simple-mocha": "~0.4.0",
     "mocha": "^2.0.0",
     "nconf": "^0.8.4"


### PR DESCRIPTION
selenium web driver was outdated with a node security advisory and so were a bunch of dev depends 

```
"vulnerabilities": [
      {
        "name": "ws",
        "version": "0.8.1",
        "path": "nemo-datadrive@2.0.3 => nemo@2.2.0 => selenium-webdriver@2.48.2 => ws@0.8.1",
        "patchTo": ">=1.0.1",
        "problem": "Remote Memory Disclosure"
      }
    ]
```

<img width="473" alt="screen shot 2016-05-20 at 10 05 54 am" src="https://cloud.githubusercontent.com/assets/1854811/15440717/b0829672-1e72-11e6-85f0-1a7c483d0a6f.png">
