### PR TITLE
Fixed capabilities in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # nemo CHANGELOG
 
+## Unreleased
+- Fix: [#115](https://github.com/paypal/nemo/issues/115)
+
 ## v2.3.0
 
 Selenium web driver was outdated and had a node security advisory. Bumped other outdated modules;

--- a/examples/setup.js
+++ b/examples/setup.js
@@ -14,7 +14,7 @@ Nemo({
   nemo.driver.get(nemo.data.baseUrl);
   nemo.driver.getCapabilities().
     then(function (caps) {
-      console.info("Nemo successfully launched", caps.caps_.browserName);
+      console.log("Nemo successfully launched", caps.get('browserName'));
     });
   nemo.driver.quit();
 });


### PR DESCRIPTION
Starting [selenium-webdriver@2.52.0](https://github.com/SeleniumHQ/selenium/blob/master/javascript/node/selenium-webdriver/CHANGES.md#v2520) capabilities object no longer has `_caps` property. Instead now Capabilities class extends the native Map. This addresses issue https://github.com/paypal/nemo/issues/115