### PR TITLE
Fixing errors for debug module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 - Fix: [#115](https://github.com/paypal/nemo/issues/115)
+- %j placeholder for debug module doesn't print Error objects. %s should be used instead for Strings and Error objects.
+%j is appropriate where we expect JSON objects and want logger to convert JSON.stringify() for us
+- Enhanced error message when plugin is not found
+- Changed default local unit tests to run on PhantomJS only
+- Added section to elaborate on how to run unit tests
 
 ## v2.3.0
 

--- a/README.md
+++ b/README.md
@@ -586,3 +586,20 @@ $ DEBUG=nemo:error <nemo command>
 Because we NEed MOre automation testing!
 
 [![NPM](https://nodei.co/npm/nemo.png?downloads=true&stars=true)](https://nodei.co/npm/nemo/)
+
+## Unit Tests
+
+* Unit tests run by default using headless browser [PhantomJS](http://phantomjs.org/). To run unit tests out of box, You must have PhantomJS installed on your system and must be present in the path
+    * Download PhantomJS from [here](http://phantomjs.org/download.html)
+    * On OSX, you can optionally use `brew` to install PhantomJS like `brew install phantomjs`
+    * PhantomJS installation detailed guide on Ubuntu can be found [here](https://gist.github.com/julionc/7476620)
+
+* If you want to run unit tests on your local browser, like lets say Firefox/Chrome (make sure ChromeDriver is in current path), you need to update browser in unit test
+configuration, for example the browser section under `test/config/config.json` like [here](https://github.com/paypal/nemo/blob/master/test/config/config.json#L19)
+
+* How to run unit tests?
+  * `grunt simplemocha` will just run unit tests
+  * `grunt` - default grunt task will run linting as well as unit tests
+  * To run directly using mocha assuming its globally installed on your system `mocha -t 60s`
+  * Or a specific test,  `mocha --grep @allArgs@ -t 60s`
+  * Or post `npm install` on nemo module, you can run `node_modules/.bin/mocha --grep @allArgs@ -t 60s`

--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Because we NEed MOre automation testing!
 configuration, for example the browser section under `test/config/config.json` like [here](https://github.com/paypal/nemo/blob/master/test/config/config.json#L19)
 
 * How to run unit tests?
+  * `npm test` will run unit tests as well as lint task
   * `grunt simplemocha` will just run unit tests
   * `grunt` - default grunt task will run linting as well as unit tests
   * To run directly using mocha assuming its globally installed on your system `mocha -t 60s`

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function Nemo(_basedir, _configOverride, _cb) {
     confitOptions.basedir = path.join(basedir, 'config');
   }
   log('confit options', confitOptions);
-  log('confit overrides: \ndata: %j,\ndriver: %j\nplugins: %j', envdata.json, envdriver.json, envplugins.json);
+  log('confit overrides: \ndata: %s,\ndriver: %s\nplugins: %s', envdata.json, envdriver.json, envplugins.json);
   //merge any environment JSON into configOverride
   _.merge(configOverride, envdata.json, envdriver.json, envplugins.json);
 
@@ -163,7 +163,7 @@ var setup = function setup(config, cb) {
       pluginModule = require(modulePath);
     } catch (err) {
       error(err);
-      var noPluginModuleError = new Error('Nemo plugin has invalid module');
+      var noPluginModuleError = new Error('Nemo plugin has invalid module %s' , modulePath);
       noPluginModuleError.name = 'nemoNoPluginModuleError';
       cb(noPluginModuleError);
       pluginError = true;

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ var setup = function setup(config, cb) {
       pluginModule = require(modulePath);
     } catch (err) {
       error(err);
-      var noPluginModuleError = new Error('Nemo plugin has invalid module %s' , modulePath);
+      var noPluginModuleError = new Error('Nemo plugin has invalid module ' + modulePath);
       noPluginModuleError.name = 'nemoNoPluginModuleError';
       cb(noPluginModuleError);
       pluginError = true;

--- a/setup/index.js
+++ b/setup/index.js
@@ -119,7 +119,7 @@ function Setup() {
         log('builder FINAL', builder);
         driver = builder.build();
       } catch (err) {
-        error('Encountered an error during driver setup: %j', err);
+        error('Encountered an error during driver setup: %s', err);
         errorObject = err;
         callback(errorObject);
         return;
@@ -127,7 +127,7 @@ function Setup() {
       driver.getSession().then(function () {
         callback(null, driver);
       }).thenCatch(function (err) {
-        error('Encountered an error during driver getSession: %j', err);
+        error('Encountered an error during driver getSession: %s', err);
         callback(err);
       });
 

--- a/setup/index.js
+++ b/setup/index.js
@@ -119,7 +119,7 @@ function Setup() {
         log('builder FINAL', builder);
         driver = builder.build();
       } catch (err) {
-        error('Encountered an error during driver setup: %s', err);
+        error('Encountered an error during driver setup: %j', err);
         errorObject = err;
         callback(errorObject);
         return;

--- a/setup/index.js
+++ b/setup/index.js
@@ -119,7 +119,7 @@ function Setup() {
         log('builder FINAL', builder);
         driver = builder.build();
       } catch (err) {
-        error('Encountered an error during driver setup: %j', err);
+        error('Encountered an error during driver setup: %s', err);
         errorObject = err;
         callback(errorObject);
         return;

--- a/test/config/development.json
+++ b/test/config/development.json
@@ -1,7 +1,7 @@
 {
   "driver": {
     "builders": {
-      "forBrowser": ["chrome"]
+      "forBrowser": ["phantomjs"]
     }
   }
 }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -26,15 +26,15 @@ describe('@plugin@', function () {
       },
       'plugins': {
         'noexist': {
-          'module': 'path:plugin/sampe'
+          'module': 'ModuleThatDoesNotExist'
         }
       }
   }, function (err) {
-      if (err && err.name && err.name === 'nemoNoPluginModuleError') {
-        done();
-        return;
-      }
-      done(new Error('didnt get the correct exception'));
+        if (err && err.name && err.name === 'nemoNoPluginModuleError' && err.message.includes('ModuleThatDoesNotExist')) {
+            done();
+            return;
+        }
+        done(new Error('didnt get the correct exception'));
     });
   });
   it('should handle @failedPluginRegistration@', function (done) {


### PR DESCRIPTION
- %j placeholder for debug module doesn't print Error objects. %s should be used instead for Strings and Error objects. %j is appropriate where we expect JSON objects and want logger to conver `JSON.stringify()` for us

For example with %j, it prints error like

`Wed, 03 Aug 2016 02:47:58 GMT nemo:error Encountered an error during driver setup: {}`
 
With %s now we have proper error,

```
Wed, 03 Aug 2016 02:47:11 GMT nemo:error Encountered an error during driver setup: 
Error: The ChromeDriver could not be found on the current PATH. Please download the 
latest version of the ChromeDriver from http://chromedriver.storage.googleapis.com/index.html 
and ensure it can be found on your PATH.
```
Small test verifying this,

``` javascript
var debug = require('debug'),
    log = debug('nemo:log'),
    s = new Error('works');
log("hello %s", s);
log("hello %j", s);
```

Output is
```
 nemo:log hello Error: works +0ms
 nemo:log hello {} +3ms
```

- Enhanced error message when no module is found
- Changed default local unit tests to run on PhantomJS only. I had PhantomJS installed but no ChromeDriver in path and it failed to run tests
- Added section to elaborate on how to run unit tests just like nemo-view