### PR TITLE
Install Selenium only if required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # nemo CHANGELOG
 
+## Unreleased
+
+- Fix [#131](https://github.com/paypal/nemo/pull/131): Improve error messages during plugin setup
+- Fix [#132](https://github.com/paypal/nemo/pull/132): Install Selenium only if required
+
 ## v2.3.1
 
 - Fix: [#115](https://github.com/paypal/nemo/issues/115)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-simple-mocha": "~0.4.0",
     "mocha": "^2.0.0",
-    "nconf": "^0.8.4"
+    "nconf": "^0.8.4",
+    "rewire": "^2.5.2"
   },
   "repository": {
     "type": "git",
@@ -37,7 +38,8 @@
   "contributors": [
     "Matt Edelman <medelman@paypal.com>",
     "Nilesh Kulkarni <nikulkarni@paypal.com>",
-    "Shay Davidson <shay.h.davidson@gmail.com>"
+    "Shay Davidson <shay.h.davidson@gmail.com>",
+    "Kushang Gajjar <g.kushang@gmail.com>"
   ],
   "licenses": [
     {

--- a/setup/seleniumInstall.js
+++ b/setup/seleniumInstall.js
@@ -4,18 +4,21 @@ var path = require('path'),
   log = debug('nemo:log'),
   error = debug('nemo:error'),
   fs = require('fs'),
+  _ = require('lodash'),
   exec = require('child_process').exec;
 
 var seleniumInstall = function (version) {
   return function installSelenium(callback) {
-    //check package.json
-    var pkg = require(path.resolve(__dirname, '../package.json'));
-    if (pkg.dependencies['selenium-webdriver'] === version) {
+
+    var seleniumVersion = _.get(require('selenium-webdriver/package.json'), 'version');
+
+    if (seleniumVersion === version) {
       log('selenium version %s already installed', version);
       return callback(null);
     }
-    var save = (process.env.NEMO_UNIT_TEST) ? '' : '--save';
-    var cmd = 'npm install ' + save + ' selenium-webdriver@' + version;
+    var save = (process.env.NEMO_UNIT_TEST) ? '' : ' --save';
+    var cmd = 'npm install ' + save + 'selenium-webdriver@' + version;
+    log('install selenium version %s', version);
     log('npm install cmd', cmd);
     exec(cmd, {cwd: path.resolve(__dirname, '..')},
       function (err, stdout, stderr) {
@@ -33,7 +36,5 @@ var seleniumInstall = function (version) {
 
       });
   };
-
-
 };
 module.exports = seleniumInstall;

--- a/setup/seleniumInstall.js
+++ b/setup/seleniumInstall.js
@@ -4,22 +4,22 @@ var path = require('path'),
   log = debug('nemo:log'),
   error = debug('nemo:error'),
   fs = require('fs'),
-  _ = require('lodash'),
   exec = require('child_process').exec;
 
 var seleniumInstall = function (version) {
   return function installSelenium(callback) {
 
-    var seleniumVersion = _.get(require('selenium-webdriver/package.json'), 'version');
-
+    var seleniumVersion = require('selenium-webdriver/package.json').version;
     if (seleniumVersion === version) {
       log('selenium version %s already installed', version);
       return callback(null);
     }
+
     var save = (process.env.NEMO_UNIT_TEST) ? '' : ' --save';
-    var cmd = 'npm install ' + save + 'selenium-webdriver@' + version;
+    var cmd = 'npm install' + save + ' selenium-webdriver@' + version;
     log('install selenium version %s', version);
-    log('npm install cmd', cmd);
+    log(cmd);
+
     exec(cmd, {cwd: path.resolve(__dirname, '..')},
       function (err, stdout, stderr) {
         if (stdout) {

--- a/test/config.js
+++ b/test/config.js
@@ -3,7 +3,6 @@
 
 var assert = require('assert'),
   path = require('path'),
-  _ = require('lodash'),
   Nemo = require('../index');
 
 describe('@config@', function () {
@@ -39,7 +38,7 @@ describe('@config@', function () {
       }
     }, function (err, nemo) {
       assert.equal(err, undefined);
-      var seleniumVersion = _.get(require('rewire')('selenium-webdriver/package.json'), 'version');
+      var seleniumVersion = require('rewire')('selenium-webdriver/package.json').version;
       assert.equal(seleniumVersion, expectedSeleniumVersion);
       nemo.driver.quit().then(function () {
         done();

--- a/test/config.js
+++ b/test/config.js
@@ -3,6 +3,7 @@
 
 var assert = require('assert'),
   path = require('path'),
+  _ = require('lodash'),
   Nemo = require('../index');
 
 describe('@config@', function () {
@@ -28,17 +29,18 @@ describe('@config@', function () {
       });
     });
   });
+
   it('should install provided @selenium.version@', function (done) {
-    var ver = '^2.53.1';
+    var expectedSeleniumVersion = '2.53.1';
     Nemo({
       'driver': {
         'browser': 'phantomjs',
-        'selenium.version': ver
+        'selenium.version': expectedSeleniumVersion
       }
     }, function (err, nemo) {
       assert.equal(err, undefined);
-      var pac = require('selenium-webdriver/package.json');
-      assert.ok(pac.version.indexOf('2.53') !== -1);
+      var seleniumVersion = _.get(require('rewire')('selenium-webdriver/package.json'), 'version');
+      assert.equal(seleniumVersion, expectedSeleniumVersion);
       nemo.driver.quit().then(function () {
         done();
       });


### PR DESCRIPTION
If `selenium.version` is specified in the config, `seleniumInstall` installs the selenium every time even if it's already installed -- because it compares user's `selenium.version` to `nemo/package.json -> selenium-webdriver` version. 

E.g. It won't match the user's `"selenium.version": "2.53.2"` to _nemo/package.json_ `"selenium-webdriver": "^2.53.2"` version, and will reinstall the `2.53.2`. 

This PR will compare user's version with already installed `selenium-webdriver` version and proceed with installation if required.
