### PR TITLE
Fixed capabilities browserName in examples

### DIFF
--- a/examples/setupWithConfigDir.js
+++ b/examples/setupWithConfigDir.js
@@ -9,9 +9,9 @@ Nemo(__dirname, function (err, nemo) {
   }
 
   nemo.driver.get(nemo.data.baseUrl);
-  nemo.driver.getCapabilities().
-    then(function (caps) {
-      console.info("Nemo successfully launched", caps.caps_.browserName);
-    });
+  nemo.driver.getCapabilities().then(function (caps) {
+    var browserName = caps.get && caps.get('browserName') || caps.caps_.browserName;
+    console.info("Nemo successfully launched", browserName);
+  });
   nemo.driver.quit();
 });

--- a/examples/setupWithPlugin.js
+++ b/examples/setupWithPlugin.js
@@ -6,9 +6,9 @@ Nemo(basedir, function (err, nemo) {
   if (!!err) {
     console.log('Error during Nemo setup', err);
   }
-  nemo.driver.getCapabilities().
-    then(function (caps) {
-      console.info("Nemo successfully launched", caps.caps_.browserName);
+    nemo.driver.getCapabilities().then(function (caps) {
+        var browserName = caps.get && caps.get('browserName') || caps.caps_.browserName;
+        console.info("Nemo successfully launched", browserName);
     });
   nemo.driver.get(nemo.data.baseUrl);
   nemo.cookie.deleteAll();


### PR DESCRIPTION
Starting selenium-webdriver@2.52.0 capabilities object no longer has _caps property. Instead now Capabilities class extends the native Map. This addresses issue #115

These two examples were missed in https://github.com/paypal/nemo/pull/128