### PR TITLE
Correct JSON examples within README to be valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,10 +364,10 @@ Additional server properties required of the 'targetServer'
 You can also set args and jvmArgs to the selenium jar process as follows:
 
 ```javascript
-'serverProps': {
-  'port': 4444,
-  'args': ['-firefoxProfileTemplate','/Users/medelman/Desktop/ffprofiles'],
-  'jvmArgs': ['-someJvmArg', 'someJvmArgValue']
+"serverProps": {
+  "port": 4444,
+  "args": ["-firefoxProfileTemplate","/Users/medelman/Desktop/ffprofiles"],
+  "jvmArgs": ["-someJvmArg", "someJvmArgValue"]
 }
 ```
 
@@ -395,8 +395,8 @@ Default is 'direct'. For more information refer : https://selenium.googlecode.co
 
 ```javascript
 "proxyDetails" : {
-    method: "manual",
-    args: [{"http": "localhost:9001","ftp":"localhost:9001","https":"localhost:9001"}]
+    "method": "manual",
+    "args": [{"http": "localhost:9001","ftp":"localhost:9001","https":"localhost:9001"}]
 }
 ```
 
@@ -433,7 +433,7 @@ Plugins are registered with JSON like the following (will vary based on your plu
 	"plugins": {
 		"samplePlugin": {
 			"module": "path:plugin/sample-plugin",
-			"arguments: [...]
+			"arguments": [...],
 			"priority": 99
 		},
 		"view": {
@@ -483,17 +483,17 @@ Use config to reference data in other parts of the JSON configuration. E.g. in t
 
 ```javascript
 {
-  'driver': {
+  "driver": {
     ...
   },
-  'plugins': {
-    'myPlugin': {
-      'module': 'nemo-some-plugin',
-      'arguments': ['config:data.someProp']
+  "plugins": {
+    "myPlugin": {
+      "module": "nemo-some-plugin",
+      "arguments": ["config:data.someProp"]
     }
   },
-  'data': {
-    'someProp': 'someVal'
+  "data": {
+    "someProp": "someVal"
   }
 }
 ```


### PR DESCRIPTION
Some of the JSON examples within the README were invalid. This PR simply corrects those errors. 

<img width="928" alt="screen shot 2016-11-18 at 1 33 07 pm" src="https://cloud.githubusercontent.com/assets/12274057/20441700/9ea5ca54-ad93-11e6-8d50-87b780493cc6.png">

*Example of GitHub complaining about the example.*
